### PR TITLE
fix: missing / in Library/Preferences (macos) in data.js

### DIFF
--- a/app/lib/data.js
+++ b/app/lib/data.js
@@ -1,30 +1,34 @@
-const path = require('path');
-const fs = require('fs');
+const path = require("path");
+const fs = require("fs");
 
-const appDataPath = process.env.APPDATA || (process.platform === 'darwin' ? process.env.HOME + '/Library/Preferences' : '/var/local');
-const appDataDir = appDataPath + '/acid-terminal';
+const appDataPath =
+  process.env.APPDATA ||
+  (process.platform === "darwin"
+    ? process.env.HOME + "/Library/Preferences"
+    : process.env.HOME + "/acid-terminal");
+const appDataDir = appDataPath + "/acid-terminal";
 
-const cacheDataDir = appDataDir + '/cache';
+const cacheDataDir = appDataDir + "/cache";
 
 const store = {
   settings: {
-    theme: 'dark',
-    fontSize: '12px',
-    font: 'JetBrains Mono, monospace',
+    theme: "dark",
+    fontSize: "12px",
+    font: "JetBrains Mono, monospace",
 
     colors: {
-      "background": "#121212",
-      "shape": "#ffffff",
-      "text": "#ffffff",
+      background: "#121212",
+      shape: "#ffffff",
+      text: "#ffffff",
       "tag-cr": "#e52e4d",
       "tag-cg": "#33cc95",
       "tag-cy": "#e5e52e",
       "tag-cb": "#6933ff",
       "tag-co": "#ff872c",
       "tag-cp": "#5429cc",
-    }
-  }
-}
+    },
+  },
+};
 
 function checkRootDir() {
   if (!fs.existsSync(appDataDir)) {
@@ -35,14 +39,16 @@ function rootDirExists() {
   return fs.existsSync(appDataDir);
 }
 function savedDataExists() {
-  return fs.existsSync(cacheDataDir + '/data.json');
+  return fs.existsSync(cacheDataDir + "/data.json");
 }
 function saveData() {
-  fs.writeFileSync(cacheDataDir + '/data.json', JSON.stringify(store));
+  fs.writeFileSync(cacheDataDir + "/data.json", JSON.stringify(store));
 }
 
 function loadData() {
-  const data = JSON.parse(fs.readFileSync(cacheDataDir + '/data.json').toString());
+  const data = JSON.parse(
+    fs.readFileSync(cacheDataDir + "/data.json").toString(),
+  );
   store.player = Object.assign(new Player(), data.player);
   store.settings = Object.assign(new Settings(), data.settings);
 }
@@ -55,25 +61,25 @@ function resetData() {
 }
 exports.resetData = resetData;
 
-if(!rootDirExists()) {
+if (!rootDirExists()) {
   checkRootDir();
   fs.mkdirSync(cacheDataDir);
   saveData();
 }
 
 function cacheData() {
-  const filePath = path.resolve(cacheDataDir, './data.json');
-  const data = fs.readFileSync(filePath, 'utf-8');
-  
+  const filePath = path.resolve(cacheDataDir, "./data.json");
+  const data = fs.readFileSync(filePath, "utf-8");
+
   return JSON.parse(data);
 }
 exports.cacheData = cacheData;
 
 function setCacheData(a) {
-  const filePath = path.resolve(cacheDataDir, './data.json');
+  const filePath = path.resolve(cacheDataDir, "./data.json");
   const data = JSON.stringify(a);
 
-  fs.writeFileSync(filePath, data, 'utf-8');
+  fs.writeFileSync(filePath, data, "utf-8");
 
   return data;
 }

--- a/app/lib/data.js
+++ b/app/lib/data.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 
-const appDataPath = process.env.APPDATA || (process.platform === 'darwin' ? process.env.HOME + 'Library/Preferences' : '/var/local');
+const appDataPath = process.env.APPDATA || (process.platform === 'darwin' ? process.env.HOME + '/Library/Preferences' : '/var/local');
 const appDataDir = appDataPath + '/acid-terminal';
 
 const cacheDataDir = appDataDir + '/cache';


### PR DESCRIPTION
When loading the application on an Apple device, an error was raised: `(node:PID) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, mkdir '/Users/(username)Library/Preferences/acid-terminal'`

This PR fixes the fact that there was no / after the username.